### PR TITLE
Fixing install command in Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Flag utility for [`styled-components`](https://github.com/styled-components/styl
 ## Install
 
 ```
-yarn add --dev styled-is
+yarn add styled-is
 ```
 
 ## Usage


### PR DESCRIPTION
This isn't a dev dependency, so should not be installed with the `--dev` flag.