### PR TITLE
Internals refactoring

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,13 +1,12 @@
 import { css } from 'styled-components';
 
-export default (...names) => (...args) => props =>
-  names.every(name => props[name]) ? css(...args) : css``;
+const styledIf = (method, condition) => (...names) => (...args) => props =>
+  names[method](name => props[name] === condition) && css(...args);
 
-export const isNot = (...names) => (...args) => props =>
-  names.every(name => !props[name]) ? css(...args) : css``;
+const is = styledIf('every', true);
+const isNot = styledIf('every', false);
+const isOr = styledIf('some', true);
+const isSomeNot = styledIf('some', false);
 
-export const isOr = (...names) => (...args) => props =>
-  names.some(name => props[name]) ? css(...args) : css``;
-
-export const isSomeNot = (...names) => (...args) => props =>
-  names.some(name => !props[name]) ? css(...args) : css``;
+export default is;
+export { isNot, isOr, isSomeNot };

--- a/test/index.js
+++ b/test/index.js
@@ -4,7 +4,7 @@ const test = require('ava');
 test('should render only if prop is truthy', t => {
   const rule = is('test')`hello`;
 
-  t.deepEqual(rule({ test: false }), []);
+  t.deepEqual(rule({ test: false }), false);
   t.deepEqual(rule({ test: true }), ['hello']);
 });
 
@@ -12,32 +12,32 @@ test('should render only if prop is falsy', t => {
   const rule = isNot('test')`hello`;
 
   t.deepEqual(rule({ test: false }), ['hello']);
-  t.deepEqual(rule({ test: true }), []);
+  t.deepEqual(rule({ test: true }), false);
 });
 
 test('should render only if all props are truthy', t => {
   const rule = is('t1', 't2')`hello`;
 
-  t.deepEqual(rule({ t1: true, t2: false }), []);
-  t.deepEqual(rule({ t1: false, t2: false }), []);
-  t.deepEqual(rule({ t1: false, t2: true }), []);
+  t.deepEqual(rule({ t1: true, t2: false }), false);
+  t.deepEqual(rule({ t1: false, t2: false }), false);
+  t.deepEqual(rule({ t1: false, t2: true }), false);
   t.deepEqual(rule({ t1: true, t2: true }), ['hello']);
 });
 
 test('should render only if all props are falsy', t => {
   const rule = isNot('t1', 't2')`hello`;
 
-  t.deepEqual(rule({ t1: true, t2: false }), []);
+  t.deepEqual(rule({ t1: true, t2: false }), false);
   t.deepEqual(rule({ t1: false, t2: false }), ['hello']);
-  t.deepEqual(rule({ t1: false, t2: true }), []);
-  t.deepEqual(rule({ t1: true, t2: true }), []);
+  t.deepEqual(rule({ t1: false, t2: true }), false);
+  t.deepEqual(rule({ t1: true, t2: true }), false);
 });
 
 test('should render only if one prop is truthy', t => {
   const rule = isOr('t1', 't2')`hello`;
 
   t.deepEqual(rule({ t1: true, t2: false }), ['hello']);
-  t.deepEqual(rule({ t1: false, t2: false }), []);
+  t.deepEqual(rule({ t1: false, t2: false }), false);
   t.deepEqual(rule({ t1: false, t2: true }), ['hello']);
   t.deepEqual(rule({ t1: true, t2: true }), ['hello']);
 });
@@ -48,5 +48,5 @@ test('should render only if one prop is falsy', t => {
   t.deepEqual(rule({ t1: true, t2: false }), ['hello']);
   t.deepEqual(rule({ t1: false, t2: false }), ['hello']);
   t.deepEqual(rule({ t1: false, t2: true }), ['hello']);
-  t.deepEqual(rule({ t1: true, t2: true }), []);
+  t.deepEqual(rule({ t1: true, t2: true }), false);
 });


### PR DESCRIPTION
This PR simplifies couple of things:
- removes `css` object constructor invocation if condition is not satisfied (we don't need to do additional job in that case). Example of `&&` operator usage in [official documentation](https://www.styled-components.com/docs/faqs#can-i-nest-rules):
<img width="997" alt="screen shot 2017-09-21 at 14 25 30" src="https://user-images.githubusercontent.com/950216/30693560-cec935f4-9ed8-11e7-9e86-48ed6b1b807e.png">


- replaces repetitive function definition with `styledIf` abstraction