### PR TITLE
Match non-boolean props + function support

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -4,13 +4,33 @@
 
 import { css } from 'styled-components';
 
-const styledIf = (method, condition) => (...names) => (...args) => props =>
-  names[method](name => Boolean(props[name]) === condition) && css(...args);
+const styledIf = (method, condition) => (...names) => (...args) => props => {
+  return (
+    (method === "match"
+      ? props[names[0]] === names[1]
+      : names[method](name => {
+          return Boolean(props[name]) === condition;
+        })) && css(...handleFunctions(args, props))
+  );
+};
+
+const handleFunctions = (args, props) => {
+  const newArgs = args.slice(0);
+  for (let i = 1; i < args.length; i++) {
+    if (typeof args[i] === "function") {
+      const argCss = args[0].slice(1);
+      argCss.unshift(args[i](props) + newArgs[0][0]);
+      newArgs[0] = argCss;
+    }
+  }
+  return newArgs;
+};
 
 const is = styledIf('every', true);
 const isNot = styledIf('every', false);
 const isOr = styledIf('some', true);
 const isSomeNot = styledIf('some', false);
+const match = styledIf("match");
 
 export default is;
-export { isNot, isOr, isSomeNot };
+export { isNot, isOr, isSomeNot, match };


### PR DESCRIPTION
I made changes to allow for:

- Matching non-boolean props
        ```match("size", "medium")``` will render css if the size prop is medium


- Passing functions which automatically receive props as a parameter, then return more css conditionally

```javascript
${match("size", "large")`
      font-size: ${Typography.fontSizeMedium};
      line-height: ${LineHeight.text.normal};
      ${props =>
        props.icon && !props.content
          ? `width: 3rem;`
          : `min-width: 6rem;`}
    `};
```

If this gets approval for merging I can update the readme.
