### PR TITLE
Bug Fix:  Functions not outputting a css attribute dont work

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ Flag utility for [`styled-components`](https://github.com/styled-components/styl
 
 - [Install](#install)
 - [Usage](#usage)
+- [Examples](#examples)
 - [License](#license)
 
 ## Install

--- a/README.md
+++ b/README.md
@@ -24,8 +24,34 @@ yarn add styled-is
 
 ## Usage
 
+```is, isNot, isOr, isSomeNot``` are used for boolean props and can check one or more props at a time ```is(prop1, prop2, ...)```.
+
+```match``` is used to check the value of a prop ```match(prop, value)```.
+
+Functions can also be passed to all of the above allow for more complex prop-checking. Any functions passed in will automatically be called with the component's props. For example if you wanted to handle a button with only an icon differently for different sizes:
+
 ```js
-import is, { isNot, isOr, isSomeNot } from 'styled-is';
+${match("size", "large")`
+      font-size: 12px;
+      ${props =>
+        props.icon && !props.content
+          ? `width: 3rem;`
+          : `min-width: 6rem;`}
+    `};
+
+${match("size", "small")`
+      font-size: 9px;
+      ${props =>
+        props.icon && !props.content
+          ? `width: 1.5rem;`
+          : `min-width: 3rem;`}
+    `};
+```
+
+## Examples
+
+```js
+import is, { isNot, isOr, isSomeNot, match } from 'styled-is';
 import styled from 'styled-components';
 
 const Div = styled.div`
@@ -63,6 +89,18 @@ const Div = styled.div`
   ${isSomeNot('red', 'left')`
     wat: 1;
   `};
+
+  ${match('size', 'large')`
+    height: 64px;
+  `};
+
+  ${is('green')`
+    background-color: green;
+    ${props =>
+      props.size === 'small'
+        ? `width: 3rem;`
+        : `width: 6rem;`}
+  `};
 `;
 
 ```
@@ -88,6 +126,32 @@ const Div = styled.div`
 // float: left;
 // position: relative;
 <Div red left>
+
+// display: block;
+// opacity: 0;
+// background-color: red;
+// opacity: 1;
+// float: left;
+// position: relative;
+// height: 64px;
+<Div red left size='large'>
+
+// display: block;
+// opacity: 0;
+// float: center;
+// wat: 1;
+// background-color: green;
+// width: 6rem;
+<Div green>
+
+// display: block;
+// opacity: 0;
+// float: center;
+// wat: 1;
+// background-color: green;
+// width: 3rem;
+<Div green size='small'>
+
 ```
 
 ## License

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ yarn add styled-is
 
 ```match``` is used to check the value of a prop ```match(prop, value)```.
 
-Functions can also be passed to all of the above allow for more complex prop-checking. Any functions passed in will automatically be called with the component's props. For example if you wanted to handle a button with only an icon differently for different sizes:
+Functions can also be passed to all of the above to allow for more complex prop-checking. Any functions passed in will automatically be called with the component's props. For example if you wanted to handle a button with only an icon differently for different sizes:
 
 ```js
 ${match("size", "large")`

--- a/src/index.js
+++ b/src/index.js
@@ -15,15 +15,20 @@ const styledIf = (method, condition) => (...names) => (...args) => props => {
 };
 
 const handleFunctions = (args, props) => {
-  const newArgs = args.slice(0);
+  let css = "";
   for (let i = 1; i < args.length; i++) {
     if (typeof args[i] === "function") {
-      const argCss = args[0].slice(1);
-      argCss.unshift(args[i](props) + newArgs[0][0]);
-      newArgs[0] = argCss;
+      css = css + args[i](props);
     }
   }
-  return newArgs;
+  if (css) {
+    const newArgs = args.slice(0);
+    const argCss = args[0].slice(1);
+    argCss.unshift(css + newArgs[0][0]);
+    newArgs[0] = argCss;
+    return newArgs;
+  }
+  return args;
 };
 
 const is = styledIf('every', true);

--- a/src/index.js
+++ b/src/index.js
@@ -4,13 +4,33 @@
 
 import { css } from 'styled-components';
 
-const styledIf = (method, condition) => (...names) => (...args) => props =>
-  names[method](name => Boolean(props[name]) === condition) && css(...args);
+const styledIf = (method, condition) => (...names) => (...args) => props => {
+  return (
+    (method === "match"
+      ? props[names[0]] === names[1]
+      : names[method](name => {
+          return Boolean(props[name]) === condition;
+        })) && css(...handleFunctions(args, props))
+  );
+};
+
+const handleFunctions = (args, props) => {
+  const newArgs = args.slice(0);
+  for (let i = 1; i < args.length; i++) {
+    if (typeof args[i] === "function") {
+      const argCss = args[0].slice(1);
+      argCss.unshift(args[i](props) + newArgs[0][0]);
+      newArgs[0] = argCss;
+    }
+  }
+  return newArgs;
+};
 
 const is = styledIf('every', true);
 const isNot = styledIf('every', false);
 const isOr = styledIf('some', true);
 const isSomeNot = styledIf('some', false);
+const match = styledIf("match");
 
 export default is;
-export { isNot, isOr, isSomeNot };
+export { isNot, isOr, isSomeNot, match };

--- a/src/index.js
+++ b/src/index.js
@@ -20,7 +20,7 @@ const handleFunctions = (args, props) => {
     if (typeof args[i] === "function") {
       const output = args[i](props);
       if (output.includes(":")) {
-        css = css + args[i](props);
+        css = css + output;
       }
     }
   }

--- a/src/index.js
+++ b/src/index.js
@@ -18,7 +18,10 @@ const handleFunctions = (args, props) => {
   let css = "";
   for (let i = 1; i < args.length; i++) {
     if (typeof args[i] === "function") {
-      css = css + args[i](props);
+      const output = args[i](props);
+      if (output.includes(":")) {
+        css = css + args[i](props);
+      }
     }
   }
   if (css) {


### PR DESCRIPTION
[Issue:](https://github.com/yldio/styled-is/issues/43) Functions not outputting a css attribute dont work.

The function handler was meant only for functions outputting full css attributes, eg: ```height: 100px;``` vs just a value eg: ```100px```. 

Solution: Added a check so it only acts on full css attributes.