### PR TITLE
Add Typescript Definition File

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
   "directories": {
     "lib": "dist"
   },
+  "types": "src/index.d.ts",
   "scripts": {
     "build": "bup",
     "fmt": "prettier --config .prettierrc --write '**/*'",

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -1,0 +1,10 @@
+type BooleanProps<T> = {
+  [P in keyof T]: T[P] extends boolean ? P : never
+}[keyof T];
+
+export function match<T>(propName: keyof T, propValue: T[keyof T]);
+export function isNot<T>(...propName: BooleanProps<T>[]);
+export function isOr<T>(...propName: BooleanProps<T>[]);
+export function isSomeNot<T>(...propName: BooleanProps<T>[]);
+
+export default function is<T>(...propName: BooleanProps<T>[]);


### PR DESCRIPTION
* I'm using this with typescript...it is nice to have a little validation on only passing boolean props etc. 

* I saw [someone else felt this way](https://www.npmjs.com/package/typescript-styled-is) and rewrote the library in typescript, which of course immediately became out of date with the addition of `match` recently...instead of doing that, I think adding the typescript definition file is a better approach

Description of Solution: 
* The typings for `is`, `isNot`, `isOr`, and `isSomeNot` validate that only a boolean property is passed
* The typing for `match` validates that at least the first argument is an expected property, and that the second argument is one of the available values...I haven't figured out a way to restrict it any further than this. 

![styled-is-boolean](https://user-images.githubusercontent.com/8185671/56061610-e64e8200-5d37-11e9-9869-9ba7c1882b74.gif)

If its not desired to put this in this repo, I could open a PR at DefinitelyTyped. 
